### PR TITLE
Define SerializableHeaderContainer as a handling non-primitive headers

### DIFF
--- a/components/vramel-rabbitmq/src/main/java/com/nxttxn/vramel/components/rabbitMQ/RabbitMQConstants.java
+++ b/components/vramel-rabbitmq/src/main/java/com/nxttxn/vramel/components/rabbitMQ/RabbitMQConstants.java
@@ -36,7 +36,9 @@ public final class RabbitMQConstants {
     public static final String APP_ID = "rabbitmq.APP_ID";
     public static final String RABBITMQ_DEAD_LETTER_EXCHANGE = "x-dead-letter-exchange";
     public static final String RABBITMQ_DEAD_LETTER_ROUTING_KEY = "x-dead-letter-routing-key";
-    
+
+    public static final String VRAMEL_SERIALIZABLE_HEADERS = "rabbitmq.vramel-serializable-headers";
+
     private RabbitMQConstants() {
         //Constants class
     }

--- a/components/vramel-rabbitmq/src/main/java/com/nxttxn/vramel/components/rabbitMQ/RabbitMQEndpoint.java
+++ b/components/vramel-rabbitmq/src/main/java/com/nxttxn/vramel/components/rabbitMQ/RabbitMQEndpoint.java
@@ -164,6 +164,9 @@ public class RabbitMQEndpoint extends DefaultEndpoint {
                 // Convert LongStrings to String.
                 if (entry.getValue() instanceof LongString) {
                     message.setHeader(entry.getKey(), entry.getValue().toString());
+                } else if (entry.getKey().equals(RabbitMQConstants.VRAMEL_SERIALIZABLE_HEADERS)) {
+                    SerializableHeaderContainer serializedHeaders = new SerializableHeaderContainer((byte[])entry.getValue());
+                    serializedHeaders.deserializeInto(message);
                 } else {
                     message.setHeader(entry.getKey(), entry.getValue());
                 }

--- a/components/vramel-rabbitmq/src/main/java/com/nxttxn/vramel/components/rabbitMQ/SerializableHeaderContainer.java
+++ b/components/vramel-rabbitmq/src/main/java/com/nxttxn/vramel/components/rabbitMQ/SerializableHeaderContainer.java
@@ -1,0 +1,45 @@
+package com.nxttxn.vramel.components.rabbitMQ;
+
+import com.nxttxn.vramel.Message;
+import org.apache.commons.lang3.SerializationUtils;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * A Container of headers that implement the serializable interface.
+ */
+public class SerializableHeaderContainer {
+    private Map<String, Object> headers;
+
+    public SerializableHeaderContainer() {
+        this.headers = new HashMap<>();
+    }
+
+    public SerializableHeaderContainer(byte[] bytes) {
+        Object obj = SerializationUtils.deserialize(bytes);
+        if (obj instanceof Map) {
+            headers = (Map<String,Object>) obj;
+        }
+    }
+
+    public void put(String key, Object value) {
+        headers.put(key, value);
+    }
+
+
+    public boolean isEmpty() {
+        return headers.isEmpty();
+    }
+
+    public byte[] serialize() {
+        return SerializationUtils.serialize((Serializable) headers);
+    }
+
+    public void deserializeInto(Message message) {
+        for (Map.Entry<String, Object> entry : headers.entrySet()) {
+            message.setHeader(entry.getKey(), entry.getValue());
+        }
+    }
+}


### PR DESCRIPTION
The RabbitMQ component by default does not let you use arbitrary types as header values, it restricts it to String, BigDecimal, Number, Boolean, Date or byte[]. 

This change, encodes as a byte[] any Vramel Exchange Message header that implements Serializable in the RabbitMQProducer and deserializes them in RabbitMQConsumer. This allows us to pass any Serializable object as a header value. There are a number of places where Transactions are placed in headers.