### PR TITLE
Enable default deliver mode on rabbitmq endpoints

### DIFF
--- a/components/vramel-rabbitmq/src/main/java/com/nxttxn/vramel/components/rabbitMQ/RabbitMQEndpoint.java
+++ b/components/vramel-rabbitmq/src/main/java/com/nxttxn/vramel/components/rabbitMQ/RabbitMQEndpoint.java
@@ -67,6 +67,8 @@ public class RabbitMQEndpoint extends DefaultEndpoint {
     private boolean autoDelete = true;
 //    @UriParam(defaultValue = "true")
     private boolean durable = true;
+    // Default deliveryMode if not set on message, by default only use RabbitMQConstants.DELIVERY_MODE
+    private Integer deliveryMode;
 //    @UriParam(defaultValue = "false")
     private boolean bridgeEndpoint;
     private String queue = String.valueOf(UUID.randomUUID().toString().hashCode());
@@ -365,6 +367,15 @@ public class RabbitMQEndpoint extends DefaultEndpoint {
     public void setDurable(boolean durable) {
         this.durable = durable;
     }
+
+    public Integer getDeliveryMode() {
+        return deliveryMode;
+    }
+
+    public void setDeliveryMode(Integer deliveryMode) {
+        this.deliveryMode = deliveryMode;
+    }
+
 
     public String getQueue() {
         return queue;

--- a/components/vramel-rabbitmq/src/main/java/com/nxttxn/vramel/components/rabbitMQ/RabbitMQProducer.java
+++ b/components/vramel-rabbitmq/src/main/java/com/nxttxn/vramel/components/rabbitMQ/RabbitMQProducer.java
@@ -209,9 +209,14 @@ public class RabbitMQProducer extends DefaultProducer {
             properties.correlationId(correlationId.toString());
         }
 
-        final Object deliveryMode = exchange.getIn().getHeader(RabbitMQConstants.DELIVERY_MODE);
+        Object deliveryMode = exchange.getIn().getHeader(RabbitMQConstants.DELIVERY_MODE);
         if (deliveryMode != null) {
             properties.deliveryMode(Integer.parseInt(deliveryMode.toString()));
+        } else {
+            deliveryMode = getEndpoint().getDeliveryMode();
+            if (deliveryMode != null) {
+                properties.deliveryMode((Integer) deliveryMode);
+            }
         }
 
         final Object userId = exchange.getIn().getHeader(RabbitMQConstants.USERID);

--- a/components/vramel-rabbitmq/src/main/java/com/nxttxn/vramel/components/rabbitMQ/SerializableHeaderContainer.java
+++ b/components/vramel-rabbitmq/src/main/java/com/nxttxn/vramel/components/rabbitMQ/SerializableHeaderContainer.java
@@ -17,6 +17,7 @@ public class SerializableHeaderContainer {
         this.headers = new HashMap<>();
     }
 
+    @SuppressWarnings("unchecked")
     public SerializableHeaderContainer(byte[] bytes) {
         Object obj = SerializationUtils.deserialize(bytes);
         if (obj instanceof Map) {


### PR DESCRIPTION
This branch adds a attribute to RabbitMQEndpoint called deliveryMode which if set cause the RabbitMQProducer to used it to set the delivery_mode property of each message if the Vramel/Camel exchange has no 'rabbitmq.DELIVER_MODE' header instead.

This allows you to define a rabbitMQ endpoint as durable and persistent.