### PR TITLE
Scms 2045 make jpos timeout configurable

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Aug 09 14:11:07 EDT 2013
+#Thu Mar 23 18:07:31 EDT 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.5-bin.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-1.5-all.zip


### PR DESCRIPTION
Rather than rely on the default 5s timeout, read a config parameter called response_timeout, and default it to 30000ms.